### PR TITLE
Adds logic to prevent undefined behavior

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -4,7 +4,7 @@ class AdminsController < ApplicationController
 
     # GET /admins or /admins.json
     def index
-        if (!is_owner)
+        if (!is_owner?)
             redirect_to(new_admin_session_path, notice: "You are not authorized.")
         end
         @admins = Admin.all

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,23 +2,27 @@
 
 class ApplicationController < ActionController::Base
     before_action :authenticate_admin!
-    helper_method :is_owner
-    helper_method :is_event_creater
-    helper_method :is_member
+    helper_method :is_owner?
+    helper_method :is_event_creater?
+    helper_method :is_member?
 
     def get_privilege
-        Admin.where(email: session[:user_email]).first.privilege_level
+        user = Admin.where(email: session[:user_email]).first
+        if user == nil
+            return -1
+        end
+        return user.privilege_level
     end
 
-    def is_owner
+    def is_owner?
         get_privilege == 30
     end
 
-    def is_event_creater
+    def is_event_creater?
         get_privilege == 20
     end
 
-    def is_member
+    def is_member?
         get_privilege == 10
     end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,21 +5,22 @@
     <li>
         <%= link_to 'Organizations', organizations_path %>
     </li>
-    <% if is_owner %>
-    <li>
-        <%= link_to 'Users', admins_path %>
-    </li>
-    <% end %>
+
     <% if admin_signed_in? %>
-    <li>
-        <%= link_to 'Events', events_path %>
-    </li>
-    <li>
-        <%= link_to "Sign Out", destroy_admin_session_path %>
-    </li>
+        <% if is_owner? %>
+            <li>
+                <%= link_to 'Users', admins_path %>
+            </li>
+        <% end %>
+        <li>
+            <%= link_to 'Events', events_path %>
+        </li>
+        <li>
+            <%= link_to "Sign Out", destroy_admin_session_path %>
+        </li>
     <% else %>
-    <li>
-        <%= link_to "Sign In", root_path %>
-    </li>
+        <li>
+            <%= link_to "Sign In", root_path %>
+        </li>
     <% end %>
 </ul>


### PR DESCRIPTION
This change prevents a `nil` value from being returned and used as a boolean if the user is not signed in. This affected the shared header.