### PR TITLE
Adds generic about page to website

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+    def about
+    end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,3 @@
 class PagesController < ApplicationController
-    def about
-    end
+    def about; end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,16 @@
+<main>
+    <div class="container">
+        <div class="row">
+            <div class="col-8">
+                <section></section>
+                <section class="page-info">
+                    <h1>About</h1>
+                    <h5>About the organization.</h5>
+                </section>
+                <section>
+                    <p>Welcome to Aggie Ambassadors.</p>
+                </section>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,8 @@
   <footer class="d-flex container bg-light flex-wrap justify-content-between align-items-center py-4">
     <p class="col-md-6 mb-0" style="font-weight: 500;"><a class="text-muted text-decoration-none" href="<%= root_path %>">Aggie Ambassadors</a></p>
     <ul class="nav col-md-6 justify-content-end">
-      <li class="nav-item"><a href="<%= root_path %>" class="nav-link px-2 text-muted">Home</a></li>
+      <li class="nav-item"><a class="nav-link px-2 text-muted" href="<%= root_path %>">Home</a></li>
+      <li class="nav-item"><a class="nav-link px-2 text-muted" href="<%= about_path %>">About</a></li>
     </ul>
   </footer>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,6 +14,7 @@
           <% end %>
           <li class="nav-item"><a class="nav-link" href="<%= events_path %>">Events</a></li>
         <% end %>
+        <li class="nav-item"><a class="nav-link" href="<%= about_path %>">About</a></li>
       </ul>
       <ul class="navbar-nav">
         <% if member_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'about' => 'pages#about'
+
   resources :attendance_records do
     member do
       get :delete


### PR DESCRIPTION
This commit introduces a template page at `/about`. There are corresponding additions to the controller and view.

As specified by the customer, the about page:
- is accessible from the header
- contains a description and contact information